### PR TITLE
wrong sorting with multiple ThenBy's

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -97,6 +97,10 @@ export declare class List<T> {
      */
     GroupJoin<U>(list: List<U>, key1: (k: T) => any, key2: (k: U) => any, result: (first: T, second: List<U>) => any): List<any>;
     /**
+     * Returns the index of the first occurence of an element in the List.
+     */
+    IndexOf(element: T): number;
+    /**
      * Produces the set intersection of two sequences by using the default equality comparer to compare values.
      */
     Intersect(source: List<T>): List<T>;
@@ -125,11 +129,11 @@ export declare class List<T> {
     /**
      * Sorts the elements of a sequence in ascending order according to a key.
      */
-    OrderBy(comparator: (key: T) => any): List<T>;
+    OrderBy(keySelector: (key: T) => any): List<T>;
     /**
      * Sorts the elements of a sequence in descending order according to a key.
      */
-    OrderByDescending(comparator: (key: T) => any): List<T>;
+    OrderByDescending(keySelector: (key: T) => any): List<T>;
     /**
      * Performs a subsequent ordering of the elements in a sequence in ascending order according to a key.
      */
@@ -138,6 +142,18 @@ export declare class List<T> {
      * Performs a subsequent ordering of the elements in a sequence in descending order, according to a key.
      */
     ThenByDescending(comparator: (key: T) => any): List<T>;
+    /**
+     * Removes the first occurrence of a specific object from the List<T>.
+     */
+    Remove(element: T): boolean;
+    /**
+     * Removes all the elements that match the conditions defined by the specified predicate.
+     */
+    RemoveAll(predicate: (value?: T, index?: number, list?: T[]) => boolean): List<T>;
+    /**
+     * Removes the element at the specified index of the List<T>.
+     */
+    RemoveAt(index: number): void;
     /**
      * Reverses the order of the elements in the entire List<T>.
      */
@@ -198,6 +214,10 @@ export declare class List<T> {
      */
     ToList(): List<T>;
     /**
+     * Creates a Lookup<TKey, TElement> from an IEnumerable<T> according to specified key selector and element selector functions.
+     */
+    ToLookup(keySelector: (key: T) => any, elementSelector: (element: T) => any): any;
+    /**
      * Produces the set union of two sequences by using the default equality comparer.
      */
     Union(list: List<T>): List<T>;
@@ -209,6 +229,10 @@ export declare class List<T> {
      * Applies a specified function to the corresponding elements of two sequences, producing a sequence of the results.
      */
     Zip<U>(list: List<U>, result: (first: T, second: U) => any): List<any>;
+    /**
+     * Creates a function that negates the result of the predicate
+     */
+    private _negate(predicate);
 }
 export declare class Enumerable {
     /**

--- a/test/list.ts
+++ b/test/list.ts
@@ -297,12 +297,36 @@ test('OrderByDescending', t => {
 
 test('ThenBy', t => {
     const fruits = new List<string>(['grape', 'passionfruit', 'banana', 'mango', 'orange', 'raspberry', 'apple', 'blueberry']);
+    let originalOrder = fruits.ToArray().toString();
 
     // sort the strings first by their length and then
     // alphabetically by passing the identity selector function.
+    let sortedByStringLength = fruits.OrderBy(fruit => fruit.length);
     const result = 'apple,grape,mango,banana,orange,blueberry,raspberry,passionfruit';
-    t.is(fruits.OrderBy(fruit => fruit.length).ThenBy(fruit => fruit).ToArray().toString(), result);
+    t.is(sortedByStringLength.ThenBy(fruit => fruit).ToArray().toString(), result);
+    // check that the first sorting is independent from the second 
+    const resultForLength = 'grape,mango,apple,banana,orange,raspberry,blueberry,passionfruit';
+    t.is(sortedByStringLength.ToArray().toString(), resultForLength);
+    t.is(fruits.ToArray().toString(), originalOrder);
+
+    // test omission of OrderBy
     t.is(new List<number>([4, 5, 6, 3, 2, 1]).ThenBy(x => x).ToArray().toString(), '1,2,3,4,5,6');
+});
+
+test('ThenByMultiple', t => {
+    // see https://github.com/kutyel/linq.ts/issues/23
+    let x = {a: 2, b: 1, c: 1};
+    let y = {a: 1, b: 2, c: 2};
+    let z = {a: 1, b: 1, c: 3};
+    let unsorted = new List([x, y, z]);
+    let sorted = unsorted.OrderBy(u => u.a)
+        .ThenBy(u => u.b)
+        .ThenBy(u => u.c)
+        .ToArray();
+
+    t.is(sorted[0], z);
+    t.is(sorted[1], y);
+    t.is(sorted[2], x);
 });
 
 test('ThenByDescending', t => {


### PR DESCRIPTION
Some quite heavy refactoring of the OrderedList class. fixes #22.
You probably wan't to review it in detail, and check if that is the approach you want. 
Basically the problem was that the sorting can only determined after the last ThenBy call. In your implementation this was not fully thought-through. Hard to explain. But in debugging i saw, that the second ThenBy call erased the sorting of the first OrderBy... The sorting needs to _deferred_ (see the Remarks section of [the documentation](https://msdn.microsoft.com/en-gb/library/bb534743(v=vs.110).aspx)) and therefore I found a way to compose the comparers. And when you try to access the collection after sorting it, the composed sort is applied.