### PR TITLE
Fix FirstOrDefault and LastOrDefault conditions

### DIFF
--- a/linq.ts
+++ b/linq.ts
@@ -146,7 +146,7 @@ export class List<T> {
     public FirstOrDefault(): T;
     public FirstOrDefault(predicate: (value?: T, index?: number, list?: T[]) => boolean): T;
     public FirstOrDefault(predicate?: (value?: T, index?: number, list?: T[]) => boolean): T {
-        return this.Count() ? this.First(predicate) : undefined;
+        return this.Count(predicate) ? this.First(predicate) : undefined;
     }
 
     /**
@@ -223,7 +223,7 @@ export class List<T> {
     public LastOrDefault(): T;
     public LastOrDefault(predicate: (value?: T, index?: number, list?: T[]) => boolean): T;
     public LastOrDefault(predicate?: (value?: T, index?: number, list?: T[]) => boolean): T {
-        return this.Count() ? this.Last(predicate) : undefined;
+        return this.Count(predicate) ? this.Last(predicate) : undefined;
     }
 
     /**


### PR DESCRIPTION
Predicate is missing in Count.
It cause error when you call FirstOrDefault with predicate. It always call First(predicate) even if its condition is false. Then First() will throw an InvalidOperationException instead of return undefined.

~~I would also change the returning type from undefined to null. The original LINQ returns NULL as well. And NULL indicates that it had no object but you might sometimes get one, while undefined means that no object was expected at all. Anyway it is my preference, and it is also a breaking change so you should decide it :)~~

Edit: nvm, I've just seen [#45](https://github.com/kutyel/linq.ts/issues/45)