### PR TITLE
Add empty Any() overload

### DIFF
--- a/linq.ts
+++ b/linq.ts
@@ -49,8 +49,10 @@ export class List<T> {
     /**
      * Determines whether a sequence contains any elements.
      */
-    public Any(predicate: (value?: T, index?: number, list?: T[]) => boolean): boolean {
-        return this._elements.some(predicate);
+    public Any(): boolean;
+    public Any(predicate: (value?: T, index?: number, list?: T[]) => boolean): boolean;
+    public Any(predicate?: (value?: T, index?: number, list?: T[]) => boolean): boolean {
+        return predicate ? this._elements.some(predicate) : this._elements.length > 0;
     }
 
     /**
@@ -491,9 +493,9 @@ class ComparerHelper {
 }
 
 /**
- * Represents a sorted sequence. The methods of this class are implemented by using deferred execution. 
- * The immediate return value is an object that stores all the information that is required to perform the action. 
- * The query represented by this method is not executed until the object is enumerated either by 
+ * Represents a sorted sequence. The methods of this class are implemented by using deferred execution.
+ * The immediate return value is an object that stores all the information that is required to perform the action.
+ * The query represented by this method is not executed until the object is enumerated either by
  * calling its ToDictionary, ToLookup, ToList or ToArray methods
  */
 class OrderedList<T> extends List<T> {

--- a/test/list.ts
+++ b/test/list.ts
@@ -114,6 +114,7 @@ test('Any', t => {
 
     // determine whether any pets over age 1 are also unvaccinated.
     t.true(pets.Any(p => p.Age > 1 && p.Vaccinated === false));
+    t.true(pets.Any());
 });
 
 test('Average', t => {
@@ -176,7 +177,7 @@ test('DistinctBy', t => {
         new Pet({ Age: 8, Name: 'Barley' }),
         new Pet({ Age: 4, Name: 'Daisy' })
     ]);
-    
+
     const result = new List<Pet>([
         new Pet({ Age: 1, Name: 'Whiskers' }),
         new Pet({ Age: 4, Name: 'Boots' }),


### PR DESCRIPTION
- This should determine if there are any elements in the list without requiring a predicate.

Link to the Any() documentation 😄 

https://msdn.microsoft.com/en-us/library/system.linq.enumerable.any(v=vs.110).aspx