### PR TITLE
fix: set module to CommonJS for ts projects

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es5",
-    "module": "es2015",
+    "module": "CommonJS",
     "lib": [
       "es2015",
       "es2016",


### PR DESCRIPTION
Fix issue of 
```
export { default as List } from './list';
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:979:16)
    at Module._compile (internal/modules/cjs/loader.js:1027:27)
```

Referred docs at: https://www.typescriptlang.org/tsconfig#module

Fixes #163 