### PR TITLE
Refactor Min/Max methods with better selector and comparer overload support

### DIFF
--- a/__tests__/list.test.ts
+++ b/__tests__/list.test.ts
@@ -589,7 +589,6 @@ test('Max_invalid_function_provided', t => {
   // Provide an invalid selector (wrong type) to trigger the error
   let invalidFn = () => 0;
   
-  // @ts-ignore
   t.throws(() => people.Max(invalidFn), {
     message: /InvalidOperationException: Invalid comparer or selector function provided./
   })
@@ -696,7 +695,6 @@ test('Min_invalid_function_provided', t => {
   // Provide an invalid selector (wrong type) to trigger the error
   let invalidFn = () => 0;
   
-  // @ts-ignore
   t.throws(() => people.Min(invalidFn), {
     message: /InvalidOperationException: Invalid comparer or selector function provided./
   })

--- a/__tests__/list.test.ts
+++ b/__tests__/list.test.ts
@@ -564,18 +564,35 @@ test('LastOrDefault', t => {
 
 test('Max', t => {
   const people = new List<IPerson>([
+    { Age: 50, Name: 'Bob' },
     { Age: 15, Name: 'Cathy' },
-    { Age: 25, Name: 'Alice' },
-    { Age: 50, Name: 'Bob' }
+    { Age: 25, Name: 'Alice' }
+    
   ])
   t.is(
     people.Max(x => x.Age ?? 0),
     50
   )
   t.is(
-    new List<number>([1, 2, 3, 4, 5]).Max(),
-    5
+    new List<number>([5, 4, 3, 2, 1]).Min(),
+    1
   )
+})
+
+test('Max_invalid_function_provided', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+
+  // Provide an invalid selector (wrong type) to trigger the error
+  let invalidFn = () => 0;
+  
+  // @ts-ignore
+  t.throws(() => people.Max(invalidFn), {
+    message: /InvalidOperationException: Invalid comparer or selector function provided./
+  })
 })
 
 test('Max_undefinedComparer', t => {
@@ -590,18 +607,6 @@ test('Max_undefinedComparer', t => {
   })
 })
 
-test('Max_withSelector_undefinedComparer', t => {
-  const people = new List<IPerson>([
-    { Age: 15, Name: 'Cathy' },
-    { Age: 25, Name: 'Alice' },
-    { Age: 50, Name: 'Bob' }
-  ])
-
-  t.throws(() => people.Max(c=> new Object()), {
-    message: /InvalidOperationException: No comparer available./
-  })
-})
-
 test('Max_emptyElements', t => {
   const people = new List<IPerson>([])
 
@@ -611,10 +616,25 @@ test('Max_emptyElements', t => {
   )
 })
 
+test('Max_comparer', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+
+  let comparer = ((a: IPerson, b: IPerson) => (a.Age ?? 0) - (b.Age ?? 0));
+  
+  t.is(
+    people.Max(comparer),
+    people.Last()
+  );
+})
+
 test('Max_number', t => {
   const nums = new List<number>([
-    10,
     5,
+    10,
     -5
   ])
   t.is(
@@ -648,6 +668,7 @@ test('Max_boolean', t => {
   )
 })
 
+
 test('Min', t => {
   const people = new List<IPerson>([
     { Age: 50, Name: 'Bob' },
@@ -665,6 +686,21 @@ test('Min', t => {
   )
 })
 
+test('Min_invalid_function_provided', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+
+  // Provide an invalid selector (wrong type) to trigger the error
+  let invalidFn = () => 0;
+  
+  // @ts-ignore
+  t.throws(() => people.Min(invalidFn), {
+    message: /InvalidOperationException: Invalid comparer or selector function provided./
+  })
+})
 
 test('Min_undefinedComparer', t => {
   const people = new List<IPerson>([
@@ -678,16 +714,19 @@ test('Min_undefinedComparer', t => {
   })
 })
 
-test('Min_withSelector_undefinedComparer', t => {
+test('Min_comparer', t => {
   const people = new List<IPerson>([
     { Age: 15, Name: 'Cathy' },
     { Age: 25, Name: 'Alice' },
     { Age: 50, Name: 'Bob' }
   ])
 
-  t.throws(() => people.Min(c=> new Object()), {
-    message: /InvalidOperationException: No comparer available./
-  })
+  let comparer = ((a: IPerson, b: IPerson) => (a.Age ?? 0) - (b.Age ?? 0));
+  
+  t.is(
+    people.Min(comparer),
+    people.First()
+  );
 })
 
 test('Min_emptyElements', t => {
@@ -735,156 +774,6 @@ test('Min_boolean', t => {
     false
   )
 })
-
-test('MaxWithComparer', t => {
-  const people = new List<IPerson>([
-    { Age: 15, Name: 'Cathy' },
-    { Age: 25, Name: 'Alice' },
-    { Age: 50, Name: 'Bob' }
-  ])
-  t.is(
-    people.MaxWithComparer((x, y) => (x.Age ?? 0) - (y.Age ?? 0)),
-    people.Last()
-  )
-  t.is(
-    new List<number>([1, 2, 3, 4, 5]).Max(),
-    5
-  )
-})
-
-test('MaxWithComparer_undefinedComparer', t => {
-  const people = new List<IPerson>([
-    { Age: 15, Name: 'Cathy' },
-    { Age: 25, Name: 'Alice' },
-    { Age: 50, Name: 'Bob' }
-  ])
-
-  t.throws(() => people.MaxWithComparer(), {
-    message: /InvalidOperationException: No comparer available./
-  })
-})
-
-test('MaxWithComparer_emptyElements', t => {
-  const people = new List<IPerson>([])
-
-  t.is(
-    people.MaxWithComparer(),
-    undefined
-  )
-})
-
-test('MaxWithComparer_number', t => {
-  const nums = new List<number>([
-    10,
-    5,
-    -5
-  ])
-  t.is(
-    nums.MaxWithComparer(),
-    10
-  )
-})
-
-test('MaxWithComparer_string', t => {
-  const people = new List<string>([
-    'Cathy',
-    'Alice',
-    'Bob'
-  ])
-  t.is(
-    people.MaxWithComparer(),
-    'Cathy'
-  )
-})
-
-test('MaxWithComparer_boolean', t => {
-  const bools = new List<boolean>([
-    true,
-    false,
-    true,
-    false
-  ])
-  t.is(
-    bools.MaxWithComparer(),
-    true
-  )
-})
-
-test('MinWithComparer', t => {
-  const people = new List<IPerson>([
-    { Age: 15, Name: 'Cathy' },
-    { Age: 25, Name: 'Alice' },
-    { Age: 50, Name: 'Bob' }
-  ])
-  t.is(
-    people.MinWithComparer((x, y) => (x.Age ?? 0) - (y.Age ?? 0)),
-    people.First()
-  )
-  t.is(
-    new List<number>([1, 2, 3, 4, 5]).Min(),
-    1
-  )
-})
-
-
-test('MinWithComparer_undefinedComparer', t => {
-  const people = new List<IPerson>([
-    { Age: 15, Name: 'Cathy' },
-    { Age: 25, Name: 'Alice' },
-    { Age: 50, Name: 'Bob' }
-  ])
-
-  t.throws(() => people.MinWithComparer(), {
-    message: /InvalidOperationException: No comparer available./
-  })
-})
-
-test('MinWithComparer_emptyElements', t => {
-  const people = new List<IPerson>([])
-
-  t.is(
-    people.MinWithComparer(),
-    undefined
-  )
-})
-
-test('MinWithComparer_number', t => {
-  const nums = new List<number>([
-    10,
-    5,
-    -5
-  ])
-  t.is(
-    nums.MinWithComparer(),
-    -5
-  )
-})
-
-test('MinWithComparer_string', t => {
-  const people = new List<string>([
-    'Cathy',
-    'Alice',
-    'Bob'
-  ])
-  t.is(
-    people.MinWithComparer(),
-    'Alice'
-  )
-})
-
-test('MinWithComparer_boolean', t => {
-  const bools = new List<boolean>([
-    true,
-    false,
-    true,
-    false
-  ])
-  t.is(
-    bools.MinWithComparer(),
-    false
-  )
-})
-
 
 test('OfType', t => {
   const pets = new List<Pet>([

--- a/__tests__/list.test.ts
+++ b/__tests__/list.test.ts
@@ -561,6 +561,7 @@ test('LastOrDefault', t => {
   t.is(new List<string>().LastOrDefault('default'), 'default')
 })
 
+
 test('Max', t => {
   const people = new List<IPerson>([
     { Age: 15, Name: 'Cathy' },
@@ -569,7 +570,7 @@ test('Max', t => {
   ])
   t.is(
     people.Max(x => x.Age ?? 0),
-    people.Last()
+    50
   )
   t.is(
     new List<number>([1, 2, 3, 4, 5]).Max(),
@@ -585,6 +586,18 @@ test('Max_undefinedComparer', t => {
   ])
 
   t.throws(() => people.Max(), {
+    message: /InvalidOperationException: No comparer available./
+  })
+})
+
+test('Max_withSelector_undefinedComparer', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+
+  t.throws(() => people.Max(c=> new Object()), {
     message: /InvalidOperationException: No comparer available./
   })
 })
@@ -637,16 +650,17 @@ test('Max_boolean', t => {
 
 test('Min', t => {
   const people = new List<IPerson>([
+    { Age: 50, Name: 'Bob' },
     { Age: 15, Name: 'Cathy' },
-    { Age: 25, Name: 'Alice' },
-    { Age: 50, Name: 'Bob' }
+    { Age: 25, Name: 'Alice' }
+    
   ])
   t.is(
     people.Min(x => x.Age ?? 0),
-    people.First()
+    15
   )
   t.is(
-    new List<number>([1, 2, 3, 4, 5]).Min(),
+    new List<number>([5, 4, 3, 2, 1]).Min(),
     1
   )
 })
@@ -660,6 +674,18 @@ test('Min_undefinedComparer', t => {
   ])
 
   t.throws(() => people.Min(), {
+    message: /InvalidOperationException: No comparer available./
+  })
+})
+
+test('Min_withSelector_undefinedComparer', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+
+  t.throws(() => people.Min(c=> new Object()), {
     message: /InvalidOperationException: No comparer available./
   })
 })
@@ -706,6 +732,155 @@ test('Min_boolean', t => {
   ])
   t.is(
     bools.Min(),
+    false
+  )
+})
+
+test('MaxWithComparer', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+  t.is(
+    people.MaxWithComparer(x => x.Age ?? 0),
+    people.Last()
+  )
+  t.is(
+    new List<number>([1, 2, 3, 4, 5]).Max(),
+    5
+  )
+})
+
+test('MaxWithComparer_undefinedComparer', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+
+  t.throws(() => people.MaxWithComparer(), {
+    message: /InvalidOperationException: No comparer available./
+  })
+})
+
+test('MaxWithComparer_emptyElements', t => {
+  const people = new List<IPerson>([])
+
+  t.is(
+    people.MaxWithComparer(),
+    undefined
+  )
+})
+
+test('MaxWithComparer_number', t => {
+  const nums = new List<number>([
+    10,
+    5,
+    -5
+  ])
+  t.is(
+    nums.MaxWithComparer(),
+    10
+  )
+})
+
+test('MaxWithComparer_string', t => {
+  const people = new List<string>([
+    'Cathy',
+    'Alice',
+    'Bob'
+  ])
+  t.is(
+    people.MaxWithComparer(),
+    'Cathy'
+  )
+})
+
+test('MaxWithComparer_boolean', t => {
+  const bools = new List<boolean>([
+    true,
+    false,
+    true,
+    false
+  ])
+  t.is(
+    bools.MaxWithComparer(),
+    true
+  )
+})
+
+test('MinWithComparer', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+  t.is(
+    people.MinWithComparer(x => x.Age ?? 0),
+    people.First()
+  )
+  t.is(
+    new List<number>([1, 2, 3, 4, 5]).Min(),
+    1
+  )
+})
+
+
+test('MinWithComparer_undefinedComparer', t => {
+  const people = new List<IPerson>([
+    { Age: 15, Name: 'Cathy' },
+    { Age: 25, Name: 'Alice' },
+    { Age: 50, Name: 'Bob' }
+  ])
+
+  t.throws(() => people.MinWithComparer(), {
+    message: /InvalidOperationException: No comparer available./
+  })
+})
+
+test('MinWithComparer_emptyElements', t => {
+  const people = new List<IPerson>([])
+
+  t.is(
+    people.MinWithComparer(),
+    undefined
+  )
+})
+
+test('MinWithComparer_number', t => {
+  const nums = new List<number>([
+    10,
+    5,
+    -5
+  ])
+  t.is(
+    nums.MinWithComparer(),
+    -5
+  )
+})
+
+test('MinWithComparer_string', t => {
+  const people = new List<string>([
+    'Cathy',
+    'Alice',
+    'Bob'
+  ])
+  t.is(
+    people.MinWithComparer(),
+    'Alice'
+  )
+})
+
+test('MinWithComparer_boolean', t => {
+  const bools = new List<boolean>([
+    true,
+    false,
+    true,
+    false
+  ])
+  t.is(
+    bools.MinWithComparer(),
     false
   )
 })
@@ -1177,12 +1352,12 @@ test('ToDictionary', t => {
   // t.is(dictionary2['Alice'], 25)
   // Dictionary should behave just like in C#
   t.is(
-    dictionary.Max(x => x?.Value?.Age ?? 0)?.Value,
-    people.Last()
+    dictionary.Max(x => x?.Value?.Age ?? 0),
+    50
   )
   t.is(
-    dictionary.Min(x => x?.Value?.Age ?? 0)?.Value,
-    people.First()
+    dictionary.Min(x => x?.Value?.Age ?? 0),
+    15
   )
   const expectedKeys = new List(['Cathy', 'Alice', 'Bob'])
   t.deepEqual(

--- a/__tests__/list.test.ts
+++ b/__tests__/list.test.ts
@@ -743,7 +743,7 @@ test('MaxWithComparer', t => {
     { Age: 50, Name: 'Bob' }
   ])
   t.is(
-    people.MaxWithComparer(x => x.Age ?? 0),
+    people.MaxWithComparer((x, y) => (x.Age ?? 0) - (y.Age ?? 0)),
     people.Last()
   )
   t.is(
@@ -817,7 +817,7 @@ test('MinWithComparer', t => {
     { Age: 50, Name: 'Bob' }
   ])
   t.is(
-    people.MinWithComparer(x => x.Age ?? 0),
+    people.MinWithComparer((x, y) => (x.Age ?? 0) - (y.Age ?? 0)),
     people.First()
   )
   t.is(

--- a/src/list.ts
+++ b/src/list.ts
@@ -328,11 +328,41 @@ class List<T> {
     const type = typeof sample;
     return List.comparers.get(type) as (a: T, b: T) => number;
   }
+  
+  /**
+   * Returns the maximum value in a generic sequence.
+   * @param selector - An optional function to extract a comparable value from each element.
+   */
+  public Max<R>(selector?: (element: T) => R): R | undefined {
+    if (this._elements.length === 0) return undefined;
+
+    if (!selector) {
+      return this.MaxWithComparer() as R |undefined;
+    }
+
+    let elements = this._elements.map(selector);
+    
+    let maxElem = elements[0];
+    let comparerToUse = List.getComparer<R>(maxElem);
+ 
+    if (!comparerToUse) {
+      throw new Error('InvalidOperationException: No comparer available.')
+    }
+
+    elements.forEach(elem => {
+      if (comparerToUse(elem, maxElem) > 0) {
+        maxElem = elem;
+      }
+    })
+
+    return maxElem;
+  }
 
   /**
    * Returns the maximum value in a generic sequence.
+   * @param comparer - An optional function to compare elements.
    */
-  public Max(comparer?: (element: T) => number): T | undefined {
+    public MaxWithComparer(comparer?: (element: T) => number): T | undefined {
     if (this._elements.length === 0) return undefined;
 
     let maxElem = this._elements[0];
@@ -353,8 +383,38 @@ class List<T> {
 
   /**
    * Returns the minimum value in a generic sequence.
+   * @param selector - An optional function to extract a comparable value from each element.
    */
-  public Min(comparer?: (element: T) => number): T | undefined {
+  public Min<R>(selector?: (element: T) => R): R | undefined {
+    if (this._elements.length === 0) return undefined;
+
+    if (!selector) {
+      return this.MinWithComparer() as R |undefined;
+    }
+
+    let elements = this._elements.map(selector);
+    
+    let minElem = elements[0];
+    let comparerToUse = List.getComparer<R>(minElem);
+ 
+    if (!comparerToUse) {
+      throw new Error('InvalidOperationException: No comparer available.')
+    }
+
+    elements.forEach(elem => {
+      if (comparerToUse(elem, minElem) < 0) {
+        minElem = elem;
+      }
+    })
+
+    return minElem;
+  }
+
+  /**
+   * Returns the minimum value in a generic sequence.
+   * @param comparer - An optional function to compare elements.
+   */
+    public MinWithComparer(comparer?: (element: T) => number): T | undefined {
     if (this._elements.length === 0) return undefined;
 
     let minElem = this._elements[0];
@@ -369,6 +429,7 @@ class List<T> {
         minElem = elem;
       }
     })
+
     return minElem;
   }
 

--- a/src/list.ts
+++ b/src/list.ts
@@ -387,21 +387,17 @@ class List<T> {
    * @param customComparer - An optional custom comparison function.
    */
   private getMaxElement<R>(elements: R[], customComparer?: ((a: R, b: R) => number)) {
-    let result = elements[0];
-
-    const comparerToUse = customComparer || List.getComparer<R>(result);
+    const comparerToUse = customComparer || List.getComparer<R>(elements[0]);
 
     if (!comparerToUse) {
       throw new Error('InvalidOperationException: No comparer available.')
     }
 
-    elements.forEach(elem => {
-      if (comparerToUse(elem, result) > 0) {
-        result = elem;
-      }
-    });
-
-    return result;
+    return elements.reduce(
+      (currentMax, elem) =>
+        comparerToUse(elem, currentMax) > 0 ? elem : currentMax,
+      elements[0]
+    );
   }
 
   /**
@@ -461,21 +457,17 @@ class List<T> {
    * @param customComparer - An optional custom comparison function.
    */
   private getMinElement<R>(elements: R[], customComparer?: ((a: R, b: R) => number)) {
-    let result = elements[0];
-
-    const comparerToUse = customComparer || List.getComparer<R>(result);
+    const comparerToUse = customComparer || List.getComparer<R>(elements[0]);
 
     if (!comparerToUse) {
       throw new Error('InvalidOperationException: No comparer available.')
     }
 
-    elements.forEach(elem => {
-      if (comparerToUse(elem, result) < 0) {
-        result = elem;
-      }
-    });
-
-    return result;
+    return elements.reduce(
+      (currentMin, elem) =>
+        comparerToUse(elem, currentMin) < 0 ? elem : currentMin,
+      elements[0]
+    );
   }
 
   /**

--- a/src/list.ts
+++ b/src/list.ts
@@ -362,7 +362,7 @@ class List<T> {
    * Returns the maximum value in a generic sequence.
    * @param comparer - An optional function to compare elements.
    */
-    public MaxWithComparer(comparer?: (element: T) => number): T | undefined {
+    public MaxWithComparer(comparer?: (a: T, b: T) => number): T | undefined {
     if (this._elements.length === 0) return undefined;
 
     let maxElem = this._elements[0];
@@ -414,7 +414,7 @@ class List<T> {
    * Returns the minimum value in a generic sequence.
    * @param comparer - An optional function to compare elements.
    */
-    public MinWithComparer(comparer?: (element: T) => number): T | undefined {
+    public MinWithComparer(comparer?: (a: T, b: T) => number): T | undefined {
     if (this._elements.length === 0) return undefined;
 
     let minElem = this._elements[0];

--- a/src/list.ts
+++ b/src/list.ts
@@ -389,7 +389,7 @@ class List<T> {
   private getMaxElement<R>(elements: R[], customComparer?: ((a: R, b: R) => number)) {
     let result = elements[0];
 
-    let comparerToUse = customComparer || List.getComparer<R>(result);
+    const comparerToUse = customComparer || List.getComparer<R>(result);
 
     if (!comparerToUse) {
       throw new Error('InvalidOperationException: No comparer available.')
@@ -463,7 +463,7 @@ class List<T> {
   private getMinElement<R>(elements: R[], customComparer?: ((a: R, b: R) => number)) {
     let result = elements[0];
 
-    let comparerToUse = customComparer || List.getComparer<R>(result);
+    const comparerToUse = customComparer || List.getComparer<R>(result);
 
     if (!comparerToUse) {
       throw new Error('InvalidOperationException: No comparer available.')

--- a/src/list.ts
+++ b/src/list.ts
@@ -328,109 +328,154 @@ class List<T> {
     const type = typeof sample;
     return List.comparers.get(type) as (a: T, b: T) => number;
   }
-  
+
   /**
-   * Returns the maximum value in a generic sequence.
-   * @param selector - An optional function to extract a comparable value from each element.
+   * Gets the maximum value in a generic sequence.
+   * @returns The maximum value in the sequence, or undefined if the sequence is empty.
    */
-  public Max<R>(selector?: (element: T) => R): R | undefined {
+  public Max(): T | undefined;
+
+  /**
+ * Gets the maximum value in a generic sequence.
+ * @returns The maximum value in the sequence, or undefined if the sequence is empty.
+ * @param selector - A function to select a value from each element for comparison.
+  */
+  public Max<R>(selector: (e: T) => R): R | undefined;
+
+  /**
+   * Gets the maximum value in a generic sequence.
+   * @returns The maximum value in the sequence, or undefined if the sequence is empty.
+   * @param comparer - A custom comparison function
+   */
+  public Max(comparer: (a: T, b: T) => number): T | undefined;
+
+  /**
+   * Gets the maximum value in a generic sequence.
+   * @returns The maximum value in the sequence, or undefined if the sequence is empty.
+    * @param comparerOrSelector - An optional custom comparison function or a selector function to select a value from each element for comparison.
+   */
+  public Max<R>(
+    comparerOrSelector?: ((a: T, b: T) => number) | ((e: T) => R)
+  ): T | R | undefined {
     if (this._elements.length === 0) return undefined;
 
-    if (!selector) {
-      return this.MaxWithComparer() as R |undefined;
+    if (!comparerOrSelector) {
+      // Max(): T | undefined;
+      return this.getMaxElement<T>(this._elements);
+
     }
 
-    let elements = this._elements.map(selector);
-    
-    let maxElem = elements[0];
-    let comparerToUse = List.getComparer<R>(maxElem);
- 
+    const fn = comparerOrSelector as Function;
+
+    if (!fn || fn.length > 2 || fn.length === 0) {
+      throw new Error('InvalidOperationException: Invalid comparer or selector function provided.')
+    }
+
+    if (fn.length === 1) {
+      // Max<R>(selector: (e: T) => R): R | undefined;
+      return this.getMaxElement<R>(this._elements.map(fn as (e: T) => R));
+    }
+
+    //fn.length === 2
+    // Max(comparer: (a: T, b: T) => number): T | undefined;
+    return this.getMaxElement<T>(this._elements, fn as (a: T, b: T) => number);
+  }
+
+  /**
+   * Returns the maximum value in a generic sequence.
+   * @param elements - The array of elements to find the maximum from.
+   * @param customComparer - An optional custom comparison function.
+   */
+  private getMaxElement<R>(elements: R[], customComparer?: ((a: R, b: R) => number)) {
+    let result = elements[0];
+
+    let comparerToUse = customComparer || List.getComparer<R>(result);
+
     if (!comparerToUse) {
       throw new Error('InvalidOperationException: No comparer available.')
     }
 
     elements.forEach(elem => {
-      if (comparerToUse(elem, maxElem) > 0) {
-        maxElem = elem;
+      if (comparerToUse(elem, result) > 0) {
+        result = elem;
       }
-    })
+    });
 
-    return maxElem;
+    return result;
   }
 
   /**
-   * Returns the maximum value in a generic sequence.
-   * @param comparer - An optional function to compare elements.
+   * Gets the minimum value in a generic sequence.
+   * @returns The minimum value in the sequence, or undefined if the sequence is empty.
    */
-    public MaxWithComparer(comparer?: (a: T, b: T) => number): T | undefined {
+  public Min(): T | undefined;
+
+  /**
+ * Gets the minimum value in a generic sequence.
+ * @returns The minimum value in the sequence, or undefined if the sequence is empty.
+ * @param selector - A function to select a value from each element for comparison.
+  */
+  public Min<R>(selector: (e: T) => R): R | undefined;
+
+  /**
+   * Gets the minimum value in a generic sequence.
+   * @returns The minimum value in the sequence, or undefined if the sequence is empty.
+   * @param comparer - A custom comparison function
+   */
+  public Min(comparer: (a: T, b: T) => number): T | undefined;
+
+  /**
+   * Gets the minimum value in a generic sequence.
+   * @returns The minimum value in the sequence, or undefined if the sequence is empty.
+    * @param comparerOrSelector - An optional custom comparison function or a selector function to select a value from each element for comparison.
+   */
+  public Min<R>(
+    comparerOrSelector?: ((a: T, b: T) => number) | ((e: T) => R)
+  ): T | R | undefined {
     if (this._elements.length === 0) return undefined;
 
-    let maxElem = this._elements[0];
-    let comparerToUse = comparer || List.getComparer<T>(maxElem);
-
-    if (!comparerToUse) {
-      throw new Error('InvalidOperationException: No comparer available.')
+    if (!comparerOrSelector) {
+      // Min(): T | undefined;
+      return this.getMinElement<T>(this._elements);
     }
 
-    this._elements.forEach(elem => {
-      if (comparerToUse(elem, maxElem) > 0) {
-        maxElem = elem;
-      }
-    })
+    const fn = comparerOrSelector as Function;
 
-    return maxElem;
+    if (!fn || fn.length > 2 || fn.length === 0) {
+      throw new Error('InvalidOperationException: Invalid comparer or selector function provided.')
+    }
+
+    if (fn.length === 1) {
+      // Min<R>(selector: (e: T) => R): R | undefined;
+      return this.getMinElement<R>(this._elements.map(fn as (e: T) => R));
+    }
+
+    //fn.length === 2
+    // Min(comparer: (a: T, b: T) => number): T | undefined;
+    return this.getMinElement<T>(this._elements, fn as (a: T, b: T) => number);
   }
 
   /**
    * Returns the minimum value in a generic sequence.
-   * @param selector - An optional function to extract a comparable value from each element.
+   * @param elements - The array of elements to find the minimum from.
+   * @param customComparer - An optional custom comparison function.
    */
-  public Min<R>(selector?: (element: T) => R): R | undefined {
-    if (this._elements.length === 0) return undefined;
+  private getMinElement<R>(elements: R[], customComparer?: ((a: R, b: R) => number)) {
+    let result = elements[0];
 
-    if (!selector) {
-      return this.MinWithComparer() as R |undefined;
-    }
+    let comparerToUse = customComparer || List.getComparer<R>(result);
 
-    let elements = this._elements.map(selector);
-    
-    let minElem = elements[0];
-    let comparerToUse = List.getComparer<R>(minElem);
- 
     if (!comparerToUse) {
       throw new Error('InvalidOperationException: No comparer available.')
     }
 
     elements.forEach(elem => {
-      if (comparerToUse(elem, minElem) < 0) {
-        minElem = elem;
+      if (comparerToUse(elem, result) < 0) {
+        result = elem;
       }
-    })
+    });
 
-    return minElem;
-  }
-
-  /**
-   * Returns the minimum value in a generic sequence.
-   * @param comparer - An optional function to compare elements.
-   */
-    public MinWithComparer(comparer?: (a: T, b: T) => number): T | undefined {
-    if (this._elements.length === 0) return undefined;
-
-    let minElem = this._elements[0];
-    let comparerToUse = comparer || List.getComparer<T>(minElem);
-
-    if (!comparerToUse) {
-      throw new Error('InvalidOperationException: No comparer available.')
-    }
-
-    this._elements.forEach(elem => {
-      if (comparerToUse(elem, minElem) < 0) {
-        minElem = elem;
-      }
-    })
-
-    return minElem;
+    return result;
   }
 
   /**


### PR DESCRIPTION
# Refactor `Min`/`Max` Methods to Support Generic Selector Overloads and Separate Comparer Variants

This pull request refactors the `Min` and `Max` methods to provide greater flexibility through generic selector overloads, and separates the comparer-based logic into clearly named methods.

## Changes

- Added generic overloads:
  ```
  public Min<R>(selector?: (element: T) => R): R | undefined  
  public Max<R>(selector?: (element: T) => R): R | undefined
- Introduced comparer-specific variants:
  ```
  public MinWithComparer(comparer?: (element: T) => number): T | undefined  
  public MaxWithComparer(comparer?: (element: T) => number): T | undefined
